### PR TITLE
Make figurefigure code more memory efficient

### DIFF
--- a/FigureFigure/main.cpp
+++ b/FigureFigure/main.cpp
@@ -1,15 +1,35 @@
 #include "iostream"
 
-constexpr long SERIES_SIZE = 999;
+constexpr int SERIES_SIZE = 999;
 
-bool arrayIncludes(long *array, int size, long value)
+bool sortedArrayIncludes(long *array, int size, long value)
 {
     for (int i = 0; i < size; i++)
     {
+        if (array[i] > value)
+            return false;
         if (array[i] == value)
             return true;
     }
     return false;
+}
+
+void cleanArray(long *array, int &size, long removeuntil)
+{
+    int offset = 0;
+    for (int i = 0; i < size; i++)
+    {
+        if (array[i] < removeuntil)
+            continue; // XXX - consider <=
+        offset = i;
+        break;
+    }
+
+    for (int i = 0; i < size - offset; i++)
+    {
+        array[i] = array[i + offset];
+    }
+    size -= offset;
 }
 
 int main()
@@ -25,8 +45,13 @@ int main()
     {
         std::cout << lastadded << std::endl;
         if (size >= SERIES_SIZE)
-            return 0;
-        if (arrayIncludes(series, size, current))
+        {
+            cleanArray(series, size, current);
+            if (size >= SERIES_SIZE)
+                return 0; // Could not free any memory!
+            continue;
+        }
+        if (sortedArrayIncludes(series, size, current))
         {
             current++;
             continue;


### PR DESCRIPTION
These changes include a early exit from `arrayIncludes`, which was (thus) renamed to `sortedArrayIncludes`, as well as some memory release of the series elements that are not needed anymore to generate the next elements.

This release is triggered every time the program runs out of memory (currently hardcoded to be 999 elements).